### PR TITLE
Added bash option i to specify invariant time limit

### DIFF
--- a/src/prp
+++ b/src/prp
@@ -22,7 +22,21 @@ PREPROCESS="$BASEDIR/preprocess/preprocess"
 SEARCH="$BASEDIR/search/downward"
 
 # Settings
-INV_TIME_LIMIT="300"
+# Paths to planner components
+TRANSLATE="$BASEDIR/translate/translate.py"
+PREPROCESS="$BASEDIR/preprocess/preprocess"
+SEARCH="$BASEDIR/search/downward"
+
+# Settings
+INV_TIME_LIMIT="0"
+options=':i:'
+while getopts $options option; do
+  case "$option" in
+    i) INV_TIME_LIMIT=$OPTARG;;
+  esac
+done
+shift $((OPTIND-1))
+echo "Using invariant time limit of $INV_TIME_LIMIT s."
 
 # Check for citation request
 if [ "--citation" = "$1" ]; then


### PR DESCRIPTION
Added a bash option ("-i") to specify the maximum time limit for invariant analysis of FD.
`./prp -i 20 ../fond-benchmarks/blocksworld/domain.pddl ../fond-benchmarks/blocksworld/p8.pddl`